### PR TITLE
Add support for mkdocs rendering

### DIFF
--- a/doorstop/core/publishers/markdown.py
+++ b/doorstop/core/publishers/markdown.py
@@ -22,6 +22,9 @@ class MarkdownPublisher(BasePublisher):
 
     def format_attr_list(self, item, linkify):
         """Create a Markdown attribute list for a heading."""
+        if settings.PUBLISH_MKDOCS:
+            return ""
+
         return " {{#{u}}}".format(u=item.uid) if linkify else ""
 
     def format_ref(self, item):
@@ -136,7 +139,7 @@ class MarkdownPublisher(BasePublisher):
         """
         linkify = kwargs.get("linkify", False)
         toc = kwargs.get("toc", False)
-        if toc:
+        if toc and not settings.PUBLISH_MKDOCS:
             yield self.table_of_contents(linkify=linkify, obj=obj)
 
         yield from self._lines_markdown(obj, **kwargs)
@@ -148,6 +151,10 @@ class MarkdownPublisher(BasePublisher):
         """
         result = ""
         heading = "#" * item.depth
+
+        if settings.PUBLISH_MKDOCS:
+            heading = "#" * (item.depth + 1)
+
         level = format_level(item.level)
         if item.heading:
             text_lines = item.text.splitlines()

--- a/doorstop/settings.py
+++ b/doorstop/settings.py
@@ -49,6 +49,7 @@ STAMP_NEW_LINKS = True  # automatically stamp links upon creation
 PUBLISH_CHILD_LINKS = True  # include child links when publishing
 PUBLISH_BODY_LEVELS = True  # include levels on non-header items
 PUBLISH_HEADING_LEVELS = True  # include levels on header items
+PUBLISH_MKDOCS = False  # generate markdown for rendering by mkdocs
 ENABLE_HEADERS = True  # use headers if defined
 WRITE_LINESEPERATOR = os.linesep
 


### PR DESCRIPTION
Adds a new settings item to control the markdown output by the publish command, making it suitable for rendering using mkdocs (specifically mkdocs-material).