### PR TITLE
fix(ci): run tests with python 3.12

### DIFF
--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -75,8 +75,7 @@ jobs:
 
       - name: Run checks
         run: make check
-        # skip python 3.12 for now, as pydoctest is failing due to a bug?(s)? needs investigation.
-        if: ${{ inputs.os == 'ubuntu-latest' && matrix.python-version != '3.12'}}
+        if: ${{ inputs.os == 'ubuntu-latest' }}
 
       - name: Run demo
         run: make demo


### PR DESCRIPTION
Missed this line when updating the CI setup