### PR TITLE
Allow references to hidden file paths

### DIFF
--- a/doorstop/settings.py
+++ b/doorstop/settings.py
@@ -64,3 +64,6 @@ CACHE_PATHS = True  # cache file/directory paths and contents
 # Server settings
 SERVER_HOST = None  # '' = server not specified, None = no server in use
 SERVER_PORT = 7867
+
+# Unhidden file
+UNHIDDEN_FILEPATH = ".doorstop_unhidden"  # list of paths that should not be hidden


### PR DESCRIPTION
Doorstop excludes hidden files from paths included in its representation of the version control system files, but this means that e.g. CI config files in a hidden folder cannot be included in the references of an item.

This patch allows users to specify file patterns that should not be hidden in a file (default name: .doorstop_unhidden)