### PR TITLE
feat(doorstop): Implement external parent

### DIFF
--- a/docs/reference/document.md
+++ b/docs/reference/document.md
@@ -104,3 +104,27 @@ In `path/to/file.yml`:
   have several
   lines.
 ```
+# Beta Features
+
+## External documents
+
+**Note: When you use this feature, it is designed assuming that the external parent will be responsible for identifying the root document.**
+
+It is possible to attach an external parent document (in other words an external git repo) as a parent to a local document. 
+
+The objective of this feature is to allow reusability of previous documents or even to split the work across multiple
+repos.
+
+To use this feature you need to modify `.doorstop.yml` to be similar to:
+
+```yaml
+external_parent: <GIT URL> <-- git url to used to pull the external parent **Required**
+external_parent_tag: <GIT_TAG> <-- tag or branch to be used **REQUIRED**
+settings:
+  parent: REQ <---- PREFIX from the external document **REQUIRED**
+  digits: 3
+  prefix: REQ
+  sep: ''
+```
+
+If you need to update the external tag or parent location, run doorstop with the flag `--clean-external-docs`.

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -8,6 +8,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
+from shutil import rmtree
 from types import ModuleType
 
 from doorstop import common, settings
@@ -23,6 +24,12 @@ def findrc_file() -> Path | None:
     cwd = Path.cwd()
     doorstoprc = cwd / ".doorstoprc.py"
     return doorstoprc if doorstoprc.is_file() else None
+
+
+def clean_external() -> None:
+    external = Path.cwd() / ".doorstop-external"
+    if external.exists():
+        rmtree(external, ignore_errors=True)
 
 
 def main(args=None):  # pylint: disable=R0915
@@ -162,6 +169,12 @@ def main(args=None):  # pylint: disable=R0915
         action="store_true",
         help="display all warning-level issues as errors",
     )
+    parser.add_argument(
+        "--clean-external-docs",
+        dest="clean_ext_docs",
+        action="store_true",
+        help="Clean external documents before running any command",
+    )
 
     # Build sub-parsers
     subs = parser.add_subparsers(help="", dest="command", metavar="<command>")
@@ -181,9 +194,12 @@ def main(args=None):  # pylint: disable=R0915
 
     # Parse arguments
     args = parser.parse_args(args=args)
-
     # Configure logging
     utilities.configure_logging(args.verbose)
+
+    if args.clean_ext_docs:
+        log.info("Deleting .doorstop-external folder")
+        clean_external()
 
     # Configure settings
     run_settings = args.settings or findrc_file()

--- a/doorstop/core/builder.py
+++ b/doorstop/core/builder.py
@@ -2,8 +2,14 @@
 
 """Functions to build a tree and access documents and items."""
 
+
 import os
-from typing import List, Optional
+from collections.abc import Mapping
+from pathlib import Path
+from traceback import format_exception
+
+from dulwich import porcelain
+from dulwich.repo import Repo
 
 from doorstop import common
 from doorstop.common import DoorstopError
@@ -12,7 +18,7 @@ from doorstop.core.document import Document
 from doorstop.core.tree import Tree
 
 log = common.logger(__name__)
-_tree: Optional[Tree] = None  # implicit tree for convenience functions
+_tree: Tree | None = None  # implicit tree for convenience functions
 
 
 def build(cwd=None, root=None, request_next_number=None) -> Tree:
@@ -28,17 +34,26 @@ def build(cwd=None, root=None, request_next_number=None) -> Tree:
     :return: new :class:`~doorstop.core.tree.Tree`
 
     """
-    documents: List[Document] = []
+
+    documents: list[Document] = []
 
     # Find the root of the working copy
     cwd = cwd or os.getcwd()
     root = root or vcs.find_root(cwd)
 
+    # external parents inclusion
+    external_documents: dict[str, str] = {}  # Prefix, tag
+    external_base_path: Path | None = (
+        Path(root, ".doorstop-external") or None
+    )  # TODO: make this configurable
+
     # Find all documents in the working copy
     log.info("looking for documents in {}...".format(root))
     skip_file_name = ".doorstop.skip-all"
     if not os.path.isfile(os.path.join(root, skip_file_name)):
-        _document_from_path(root, root, documents)
+        _document_from_path(
+            root, root, documents, external_documents, external_base_path
+        )
     exclude_dirnames = {".git", ".venv", "venv"}
     if not os.path.isfile(os.path.join(root, skip_file_name)):
         for dirpath, dirnames, _ in os.walk(root, topdown=True):
@@ -50,12 +65,18 @@ def build(cwd=None, root=None, request_next_number=None) -> Tree:
                 if os.path.isfile(os.path.join(path, skip_file_name)):
                     continue
                 whilelist_dirnames.append(dirname)
-                _document_from_path(path, root, documents)
+                _document_from_path(
+                    path, root, documents, external_documents, external_base_path
+                )
             dirnames[:] = whilelist_dirnames
 
     # Build the tree
     if not documents:
         log.info("no documents found in: {}".format(root))
+
+    for document in documents:
+        log.info("found document: {}".format(document))
+
     log.info("building tree...")
     tree = Tree.from_list(documents, root=root)
     tree.request_next_number = request_next_number
@@ -66,14 +87,26 @@ def build(cwd=None, root=None, request_next_number=None) -> Tree:
     return tree
 
 
-def _document_from_path(path, root, documents):
+def _check_for_duplicates(documents: list[Document], document: Document):
+    if not any(docs.prefix == document.prefix for docs in documents):
+        documents.append(document)
+
+
+def _document_from_path(
+    path,
+    root,
+    documents: list[Document],
+    external_documents: dict[str, str],
+    external_base_path: Path | None,
+):
     """Attempt to create and append a document from the specified path.
 
     :param path: path to a potential document
     :param root: path to root of working copy
     :param documents: list of :class:`~doorstop.core.document.Document`
         to append results
-
+    :param external_documents:  dictionary to control the version of external documents
+    :param external_base_path: where external documents will be stored
     """
     try:
         document = Document(path, root, tree=None)  # tree attached later
@@ -83,8 +116,33 @@ def _document_from_path(path, root, documents):
         if document.skip:
             log.debug("skipped document: {}".format(document))
         else:
-            log.info("found document: {}".format(document))
-            documents.append(document)
+            document.load()  # force to load the properties Earlier
+            if (
+                document.external_parent and document.external_parent_tag
+            ) and external_base_path:
+                if not getattr(document, "parent"):
+                    raise DoorstopError(
+                        "Document {} @ {} have external parent configs and it doesn't have a parent prefix".format(
+                            document.prefix, document.path
+                        )
+                    )
+                log.debug(
+                    """Document has external parent
+external information:
+    external Parent: {}
+    external Tag: {}""".format(
+                        document.external_parent, document.external_parent_tag
+                    )
+                )
+
+                _download_external_parent(
+                    external_base_path,
+                    document.external_parent,
+                    document.external_parent_tag,
+                    documents,
+                    external_documents,
+                )
+            _check_for_duplicates(documents, document)
 
 
 def find_document(prefix):
@@ -120,3 +178,165 @@ def _clear_tree():
     """Force the shared tree to be rebuilt."""
     global _tree
     _tree = None
+
+
+def _create_external_dir(external_base_path: Path):
+    """Create the folder that will store pulled documents."""
+    match external_base_path.exists():
+        case True:
+            log.debug(
+                "Skipping creation folder already exists {} in {}.".format(
+                    external_base_path.parts[-1], external_base_path.parent
+                )
+            )
+        case False:
+            log.info(
+                "Creating folder {} in {}".format(
+                    external_base_path.parts[-1], external_base_path.parent
+                )
+            )
+    try:
+        external_base_path.mkdir(exist_ok=True)
+    except Exception as e:
+        tb_str = "".join(format_exception(None, e, e.__traceback__))
+        raise DoorstopError(
+            """Something unexpected has happened when trying to create folder {} in {}\n.
+                            Details: {}""".format(
+                external_base_path.parent, external_base_path.parts[-1], tb_str
+            )
+        )
+
+
+def _external_documents_check(
+    existing_external_docs: Mapping[str, str], new_external_docs: Mapping[str, str]
+):
+    results: dict[str, bool] = {}
+
+    for key in new_external_docs.keys():
+        if key in existing_external_docs:
+            results[key] = existing_external_docs[key] == new_external_docs[key]
+
+    if list(results.values()).count(False) >= 1:
+        raise DoorstopError(
+            f"""
+Different version for a prefix detected please check the external document definitions.
+Affected prefix(es) { [ x for x,v in results.items() if v is False ] }
+                             """
+        )
+
+
+def _validate_external_documents(
+    new_external_doc: Path,
+    external_document_tag: str,
+    external_documents: dict[str, str],
+    doorstop_documents: list[Document],
+):
+    """
+    Reponsible to discover external documents and add them to the doorstop main document list.
+
+    :param new_external_doc: path to a potential external document
+    :param external_document_tag: tag to track which version of the document we are using
+    :param external_documents:  dictionary to control the version of external documents format is Document Prefix: Tag (version value)
+    :param doorstop_documents: list of :class:`~doorstop.core.document.Document` to append results
+    """
+
+    def find_external_docs(external_path: Path):
+        """Reproduction partial builder's logic here for external docs."""
+        root = new_external_doc.absolute().parent
+        external_docs: list[Document] = []
+        skip_file_name = ".doorstop.skip-all"
+        exclude_dirnames = {".git", ".venv", "venv"}
+        # case git root is a document
+        if not os.path.isfile(os.path.join(root, skip_file_name)):
+            _document_from_path(
+                external_path, external_path, external_docs, external_documents, root
+            )
+
+        # search through folders
+        for dirpath, dirnames, _ in os.walk(external_path, topdown=True):
+            for dirname in dirnames:
+                if dirname in exclude_dirnames:
+                    continue
+                path = os.path.join(dirpath, dirname)
+                if os.path.isfile(os.path.join(path, skip_file_name)):
+                    continue
+                _document_from_path(
+                    path, path, external_docs, external_documents, external_path
+                )
+        return external_docs
+
+    new_external_docs = find_external_docs(new_external_doc)
+    entries = {str(d.prefix): external_document_tag for d in new_external_docs}
+    _external_documents_check(external_documents, entries)
+    # external_documents.update({k:v for k,v in entries.items() if k not in external_documents.keys()})  #TODO: is it really necessary to filter?
+    external_documents.update(entries)  # for now lets just throw the whole dict
+
+    for nrd in new_external_docs:
+        _check_for_duplicates(doorstop_documents, nrd)
+
+
+def _git_pull(git_url: str, git_tag: str, target_folder: Path):
+
+    def exact_want(refs, _depth=None):
+        tag = (
+            b"refs/heads/" + git_tag.encode()
+            if git_tag in ["main", "master"]
+            else b"refs/tags/" + git_tag.encode()
+        )
+        if tag in refs:
+            return tag
+
+        raise DoorstopError("ref {} not found in external {}".format(git_tag, git_url))
+
+    path = str(target_folder.absolute())
+    with open(os.devnull, "wb") as f:
+        if not (target_folder / ".git").exists():
+            Repo.init(path, mkdir=False)
+            porcelain.pull(
+                path,
+                git_url,
+                refspecs=exact_want(
+                    porcelain.fetch(path, git_url, errstream=f, outstream=f)
+                ),
+                errstream=f,
+                outstream=f,
+                force=True,
+                report_activity=None,
+            )
+
+
+def _download_external_parent(
+    external_base_path: Path,
+    external_parent_url: str,
+    external_parent_tag: str,
+    doorstop_documents: list[Document],
+    external_documents: dict[str, str],
+):
+
+    _create_external_dir(external_base_path)
+
+    folder_name = external_parent_url.split("/")[-1].split(".")[0]
+
+    if not folder_name:
+        raise DoorstopError(
+            "Couldn't guess a name to storage external parent, check the config for {}".format(
+                external_parent_url
+            )
+        )
+
+    try:
+        target = external_base_path / folder_name
+        _create_external_dir(target)
+        _git_pull(external_parent_url, external_parent_tag, target)
+        _validate_external_documents(
+            target, external_parent_tag, external_documents, doorstop_documents
+        )
+    except Exception as e:
+        tb_str = "".join(format_exception(None, e, e.__traceback__))
+        raise DoorstopError(
+            """Unexpected error when downloading external parent from {}
+ERROR Details: 
+    {} """.format(
+                external_parent_url, tb_str
+            )
+        )

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -77,6 +77,8 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         self._items: List[Item] = []
         self._itered = False
         self.children: List[Document] = []
+        self.external_parent: str | None = None
+        self.external_parent_tag: str | None = None
 
         if not self._data["itemformat"]:
             self._data["itemformat"] = Item.DEFAULT_ITEMFORMAT
@@ -236,6 +238,8 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
                 raise DoorstopError(msg)
 
         self.extensions = data.get("extensions", {})
+        self.external_parent = data.get("external_parent", None)
+        self.external_parent_tag = data.get("external_parent_tag", None)
 
         # Set meta attributes
         self._loaded = True

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -6,6 +6,7 @@ import functools
 import hashlib
 import linecache
 import os
+from pathlib import Path
 from typing import Any, List
 
 from doorstop import common, settings
@@ -258,7 +259,11 @@ class Item(BaseFileObject):  # pylint: disable=R0902
                 stripped_value = []
                 for ref_dict in value:
                     ref_type = ref_dict["type"]
-                    ref_path = ref_dict["path"]
+                    ref_path = (
+                        ref_dict["path"]
+                        if ".doorstop-external" not in self.path  # type: ignore
+                        else str(Path(self.root) / ref_dict["path"])
+                    )
 
                     stripped_ref_dict = {"type": ref_type, "path": ref_path.strip()}
                     if "keyword" in ref_dict:

--- a/doorstop/core/vcs/__init__.py
+++ b/doorstop/core/vcs/__init__.py
@@ -2,8 +2,8 @@
 
 """Interfaces to version control systems."""
 
-import logging
 import os
+from pathlib import Path
 
 from doorstop import common
 from doorstop.common import DoorstopError
@@ -48,9 +48,15 @@ def find_root(cwd):
 
 def load(path):
     """Return a working copy for the specified path."""
+    if ".doorstop-external" in path:
+        realpath = Path(path.split(".doorstop-external")[0])  # Cheat to get the root.
+        # We only support this with git...
+        return DIRECTORIES[".git"](realpath)  # type: ignore
+
     for directory in os.listdir(path):
         if directory in DIRECTORIES:
             return DIRECTORIES[directory](path)  # type: ignore
 
-    log.warning("no working copy found at: {}".format(path))
+    if ".doorstop-external" not in path:
+        log.warning("no working copy found at: {}".format(path))
     return DEFAULT(path)

--- a/doorstop/core/vcs/base.py
+++ b/doorstop/core/vcs/base.py
@@ -115,8 +115,11 @@ class BaseWorkingCopy(metaclass=ABCMeta):
                         log.debug(f"not skipping: {relpath}")
                         self._path_cache.append((path, filename, relpath))
                         continue
-                    # Skip hidden paths
-                    if os.path.sep + "." in os.path.sep + relpath:
+                    # Skip hidden paths except for 'external folder'
+                    if (
+                        ".doorstop-external" not in relpath
+                        and os.path.sep + "." in os.path.sep + relpath
+                    ):
                         continue
                     self._path_cache.append((path, filename, relpath))
         yield from self._path_cache

--- a/poetry.lock
+++ b/poetry.lock
@@ -400,6 +400,72 @@ files = [
 ]
 
 [[package]]
+name = "dulwich"
+version = "0.22.1"
+description = "Python Git Library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "dulwich-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:892914dc2e80403d16e59a3b440044f6092fde5ffd4ec1fdf36d6ff20a8e624d"},
+    {file = "dulwich-0.22.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b03092399f0f5d3e112405b890128afdb9e1f203eafb812f5d9105b0f5fac9d4"},
+    {file = "dulwich-0.22.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a2c790517ed884bc1b1590806222ab44989eeb7e7f14dfa915561c7ee3b9ac73"},
+    {file = "dulwich-0.22.1-cp310-cp310-win32.whl", hash = "sha256:524d3497a86f79959c9c1d729715d60d8171ed3f71621d45afb4faee5a47e8a1"},
+    {file = "dulwich-0.22.1-cp310-cp310-win_amd64.whl", hash = "sha256:d3146843b972f744aed551e8ac9fac5714baa864393e480586d467b7b4488426"},
+    {file = "dulwich-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:82f26e592e9a36ab33bcdb419c7d53320e26c85dfc254cdb84f5f561a2fcaabf"},
+    {file = "dulwich-0.22.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e90b8a2f24149c5803b733a24f1a016a2943b1f5a9ab2360db545e4638354c35"},
+    {file = "dulwich-0.22.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b069639757b2f287f9cd0daf6765b536558c5e28263bbbb28e3d1925bce75400"},
+    {file = "dulwich-0.22.1-cp311-cp311-win32.whl", hash = "sha256:3ae006498fea11515027a417e6e68b82e1c195d3516188ba2cc08210e3022d14"},
+    {file = "dulwich-0.22.1-cp311-cp311-win_amd64.whl", hash = "sha256:a18d1392eabd02f337dcba23d723a4dcca87274ce8693cf88e6320f38bc3fdcd"},
+    {file = "dulwich-0.22.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:12482e318895da9acabea7c0cc70b35d36833e7cb2def511ab3a63617f5c1af3"},
+    {file = "dulwich-0.22.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6dc42afedc8cda4f2fd15a06d2e9e41281074a02cdf31bb2e0dde4d80766a408"},
+    {file = "dulwich-0.22.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3c7774232a2c9b195bde4fb72ad71455e877a9e4e9c0b17a57b1d9bd478838c"},
+    {file = "dulwich-0.22.1-cp312-cp312-win32.whl", hash = "sha256:41dfc52db29a06fe23a5029abc3bc13503e28233b1c3a9614bc1e5c4d6adc1ce"},
+    {file = "dulwich-0.22.1-cp312-cp312-win_amd64.whl", hash = "sha256:9d19f04ecd4628a0e4587b4c4e98e040b87924c1362ae5aa27420435f05d5dd8"},
+    {file = "dulwich-0.22.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0d72a88c7af8fafa14c8743e8923c8d46bd0b850a0b7f5e34eb49201f1ead88e"},
+    {file = "dulwich-0.22.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e36c8a3bb09db5730b3d5014d087bce977e878825cdd7ba8285abcd81c43bc0"},
+    {file = "dulwich-0.22.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd51e77ff1b4ca08bc9b09b85646a3e77f275827b7b30180d76d769ce608e64d"},
+    {file = "dulwich-0.22.1-cp37-cp37m-win32.whl", hash = "sha256:739ef91aeb13fa2aa187d0efd46d0ac168301f54a6ef748565c42876b4b3ce71"},
+    {file = "dulwich-0.22.1-cp37-cp37m-win_amd64.whl", hash = "sha256:91966b7b48ec939e5083b03c9154fc450508056f01650ecb58724095307427f5"},
+    {file = "dulwich-0.22.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:86be1e283d78cc3f7daee1dcd0254122160cde71ca8c5348315156045f8ac2bb"},
+    {file = "dulwich-0.22.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926d671654a2f8cfa0b2fcb6b0c46833af95b5265d27a5c56c49c5a10f3ff3ba"},
+    {file = "dulwich-0.22.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:467ff87fc4c61a23424b32acd952476ba17e7f7eeb8090e5957f68129784a35f"},
+    {file = "dulwich-0.22.1-cp38-cp38-win32.whl", hash = "sha256:f9e10678fe0692c5167553981d97cbe342ed055c49016aef10da336e2962b1f2"},
+    {file = "dulwich-0.22.1-cp38-cp38-win_amd64.whl", hash = "sha256:6386165c64ba5f61c416301f7f32bb899f8200ca575d76888697a42fda8a92d2"},
+    {file = "dulwich-0.22.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:84db8aef08df6431b017cc3abe57b3d6885fd7436eec8d715603c309353b233c"},
+    {file = "dulwich-0.22.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:155124219e6ce4b116d30ed1b9cc63c88021966b29ce761d3ce3caba064f9a13"},
+    {file = "dulwich-0.22.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7579429e89deac6659b4ea70eb3de9063bb40508fd4a8a020fa67b02e0b59f4f"},
+    {file = "dulwich-0.22.1-cp39-cp39-win32.whl", hash = "sha256:454d073e628043dde4f9bd34517736c1889dbe6417099bbae2119873b8d4d5da"},
+    {file = "dulwich-0.22.1-cp39-cp39-win_amd64.whl", hash = "sha256:e1b51d26108a832f151da8856a93676cc1a5cd8dd0bc20f06f4aee5774a7f0f9"},
+    {file = "dulwich-0.22.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4c509e8172b9438536946097768413f297229b03eff064e4e06749cf5c28df78"},
+    {file = "dulwich-0.22.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64eebe1d709539d6e80440fa1185f1eeb260d53bcb6435b1f753b4ce90a65e82"},
+    {file = "dulwich-0.22.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:52a8ddd1d9b5681de216a7af718720f5202d3c093ecc10dd4dfac6d25da605a6"},
+    {file = "dulwich-0.22.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7244b796dd7e191753b822ac0ca871a4b9139b0b850770ac5bd347d5f8c76768"},
+    {file = "dulwich-0.22.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:e7798e842ec506d25f21e825259b70109325ac1c9b43c2e287aad7559455951b"},
+    {file = "dulwich-0.22.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac9fcf7c5cf1e9d0bcc643672f81bf43ec81f6495b99809649f5bfcdff633ab0"},
+    {file = "dulwich-0.22.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e346c1b86c5e5f175ca8f87f3873eea8b2e0eeb5d52033b475cf85641cb200c2"},
+    {file = "dulwich-0.22.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:b2054e1f2c7041857ce129443bde23298ca37592ce82f0fb5ed5704d5f3708dd"},
+    {file = "dulwich-0.22.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3ad3462d070b678fe61d3bdd7c6ac3fdbd25cca66f32b6edf589dd88fff251d2"},
+    {file = "dulwich-0.22.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc6575476539c0b4924abab3896fc76be2f413d5baa6b083c4dfc4abc59329e"},
+    {file = "dulwich-0.22.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3de7a2eba26ff13a79670f78f73fc86fb8c87100508119f3b6bd61451bfdd4bf"},
+    {file = "dulwich-0.22.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:b2c3186cf76d598a9d42b35e09ef35d499118b4197624ba5bba1b3a39ac6a75f"},
+    {file = "dulwich-0.22.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3a366cdba24b8df31ad70b82bae55baa696c453678c1346da8390396a1d5cce4"},
+    {file = "dulwich-0.22.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fb61891b2675664dc89d486eb5199e3659179ae04fc0a863ffc7e16b782b624"},
+    {file = "dulwich-0.22.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0ea4c5feedd35e8bde175a9ab91ef6705c3cef5ee209eeb2f67dd0b59ff1825f"},
+    {file = "dulwich-0.22.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:20f61f6dc0b075ca6459acbfb9527ee0e1ee02dccbed126dc492600bb7310d86"},
+    {file = "dulwich-0.22.1.tar.gz", hash = "sha256:e36d85967cfbf25da1c7bc3d6921adc5baa976969d926aaf1582bd5fd7e94758"},
+]
+
+[package.dependencies]
+setuptools = {version = "*", markers = "python_version >= \"3.12\""}
+urllib3 = ">=1.25"
+
+[package.extras]
+fastimport = ["fastimport"]
+https = ["urllib3 (>=1.24.1)"]
+paramiko = ["paramiko"]
+pgp = ["gpg"]
+
+[[package]]
 name = "et-xmlfile"
 version = "1.1.0"
 description = "An implementation of lxml.xmlfile for the standard library"
@@ -1495,4 +1561,4 @@ tests = ["PasteDeploy", "WSGIProxy2", "coverage", "pyquery", "pytest", "pytest-c
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c6c6426fff11f1ed567d92b07f7ddc42790df30b0d88d2cb4b1b83b2401fa3c5"
+content-hash = "ee7cbdb197e9ec82dec5864df0ddcad8c15ef0881b38ec1836b85113f0e0218c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ plantuml-markdown = "^3.4.2"
 six = "*" # fixes https://github.com/dougn/python-plantuml/issues/11
 openpyxl = ">=3.1.2"
 setuptools = { version = ">=70", python = ">=3.12" }
+dulwich = "^0.22.1"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
We added an implementation that pull a remote parent for a doorstop document if not present.

It also validates if you try to import a prefix twice with different tags.

- This Implementation should be capable of doing recursive pulling as well (not tested yet)