### PR TITLE
Always write a final trailing newline when dumping markdown

### DIFF
--- a/doorstop/common.py
+++ b/doorstop/common.py
@@ -350,6 +350,8 @@ def dump_markdown(data, textattr):
     text = frontmatter.dumps(
         frontmatter.Post(content, **data), Dumper=yaml.dumper.Dumper
     )
+    if text[-1] != "\n":
+        text += "\n"
     return text
 
 

--- a/doorstop/core/tests/test_common.py
+++ b/doorstop/core/tests/test_common.py
@@ -152,5 +152,5 @@ list:
 
 # header
 
-text text text""".lstrip(),
+text text text\n""".lstrip(),
         )


### PR DESCRIPTION
POSIX requires all lines (and therefore text files) to end with a newline. Currently, doorstop enforces the opposite behaviour. Doorstop strips trailing newlines from markdown records on load, which causes them to be permanently removed from the file when dumped by doorstop.

This is caused by Doorstop's internal representation for the body of a record, the `Text` type. Among other restrictions, `Text` cannot represent strings ending with a final newline. If such a newline is found, `Text`'s constructor strips it. For yaml format records and doorstop's internal representation this is a perfectly sensible choice and there is no convincing argument to change this.

Therefore, this PR resolves the identified bug by tweaking the dumping of markdown, rather than doorstop's internal representation. Now, when dumping the text body to markdown, doorstop always adds a final newline. The unit test for `common.dump_markdown` is modified to enforce this new behaviour.