### PR TITLE
Replace distutils with shutil 

### DIFF
--- a/doorstop/core/editor.py
+++ b/doorstop/core/editor.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from distutils.spawn import find_executable
+from shutil import which as find_executable
 
 from doorstop import common
 from doorstop.common import DoorstopError


### PR DESCRIPTION

[distutils was deprecated in 3.10 and removed in 3.12](https://docs.python.org/3/library/distutils.html)
so I was unable to run doorstop locally. \
[`shutil.which`](https://docs.python.org/3/library/shutil.html#shutil.which) is the intended replacement for what we use - `distutils.spawn.find_executable`. \
`shutil.which` has been around since python 3.3 so no minimum python version support should be affected. 